### PR TITLE
Labels

### DIFF
--- a/CTRex.cabal
+++ b/CTRex.cabal
@@ -17,6 +17,7 @@ Library
                  containers,
                  hashable >= 1.2,
                  mtl >= 1.0,
+                 unconstrained >= 0.1.0.1,
                  unordered-containers >= 0.2
   Exposed-modules: Data.OpenRecords
   other-modules:

--- a/Data/OpenRecords.hs
+++ b/Data/OpenRecords.hs
@@ -70,6 +70,7 @@ import GHC.TypeLits
 import GHC.Exts -- needed for constraints kinds
 import Data.Proxy
 import Data.Type.Equality (type (==))
+import Unconstrained
 
 
 -- | A label 
@@ -218,10 +219,6 @@ type family (l :: Row *) :+  (r :: Row *)  :: Row * where
 {--------------------------------------------------------------------
   Syntactic sugar for record operations
 --------------------------------------------------------------------}
--- | A constraint not constraining anything
-class NoConstr a 
-instance NoConstr a
-
 -- | Alias for ':\'. It is a class rather than an alias, so that
 --   it can be partially appliced.
 class (r :\ l) => Lacks (l :: Symbol) (r :: Row *)
@@ -266,9 +263,9 @@ infix 5 :<-
 --  [@:<-!@] Record label renaming. Sugar for 'renameUnique'.
 data RecOp (c :: Row * -> Constraint) (rowOp :: RowOp *) where
   (:<-)  :: KnownSymbol l           => Label l -> a      -> RecOp (HasType l a) RUp
-  (:=)   :: KnownSymbol l           => Label l -> a      -> RecOp NoConstr (l ::= a)  
+  (:=)   :: KnownSymbol l           => Label l -> a      -> RecOp Unconstrained1 (l ::= a)  
   (:!=)  :: KnownSymbol l => Label l -> a      -> RecOp (Lacks l) (l ::= a)  
-  (:<-|) :: (KnownSymbol l, KnownSymbol l') => Label l' -> Label l -> RecOp NoConstr (l' ::<-| l)
+  (:<-|) :: (KnownSymbol l, KnownSymbol l') => Label l' -> Label l -> RecOp Unconstrained1 (l' ::<-| l)
   (:<-!) :: (KnownSymbol l, KnownSymbol l', r :\ l') => Label l' -> Label l -> RecOp (Lacks l') (l' ::<-| l)
 
 


### PR DESCRIPTION
Define a type family of labels of a `Row`, and a convenient function to reify them (the `rinitAWithLabel` technique may not be obvious).

We need a null constraint type which can be exposed to user so they can use `labels`, ergo dependency on "unconstrained" package.
